### PR TITLE
Add predefined extend_timeout state

### DIFF
--- a/src/systemd.erl
+++ b/src/systemd.erl
@@ -9,6 +9,7 @@
     {status, unicode:chardata()} |
     {errno, non_neg_integer()} |
     {buserror, unicode:chardata()} |
+    {extend_timeout, {non_neg_integer(), erlang:time_unit()}} |
     unicode:chardata().
 -type sd_timeout() :: pos_integer().
 -type fd() :: integer() | {integer(), unicode:chardata()}.
@@ -55,6 +56,9 @@ normalize_state(watchdog_trigger) -> "WATCHDOG=trigger";
 normalize_state({status, Status}) -> ["STATUS=", Status];
 normalize_state({errno, Errno}) -> io_lib:fwrite("ERRNO=~B", [Errno]);
 normalize_state({buserror, Error}) -> ["BUSERROR=", Error];
+normalize_state({extend_timeout, {Time, Unit}}) ->
+    Microsecs = erlang:convert_time_unit(Time, Unit, microsecond),
+    io_lib:fwrite("EXTEND_TIMEOUT_USEC=~B", [Microsecs]);
 normalize_state(Msg) -> Msg.
 
 %% ----------------------------------------------------------------------------

--- a/test/systemd_SUITE.erl
+++ b/test/systemd_SUITE.erl
@@ -43,6 +43,9 @@ notify(Config) ->
     systemd:notify({status, "example status"}),
     systemd:notify({errno, 10}),
     systemd:notify({buserror, "test.example.bus.service.Error"}),
+    systemd:notify({extend_timeout, {5, microsecond}}),
+    systemd:notify({extend_timeout, {5, millisecond}}),
+    systemd:notify({extend_timeout, {5, second}}),
     systemd:notify("CUSTOM=message"),
     systemd:notify("FORMATTED=~.16b", [16#deadbeef]),
 
@@ -54,6 +57,9 @@ notify(Config) ->
                   "STATUS=example status\n",
                   "ERRNO=10\n",
                   "BUSERROR=test.example.bus.service.Error\n",
+                  "EXTEND_TIMEOUT_USEC=5\n",
+                  "EXTEND_TIMEOUT_USEC=5000\n",
+                  "EXTEND_TIMEOUT_USEC=5000000\n",
                   "CUSTOM=message\n",
                   "FORMATTED=deadbeef\n"], mock_systemd:messages(Pid)),
 


### PR DESCRIPTION
This can be used during application startup to extend time to report readiness over default limit (however you need to send that message within such limit anyway).