### PR TITLE
Add systemd formatter

### DIFF
--- a/include/systemd.hrl
+++ b/include/systemd.hrl
@@ -1,0 +1,8 @@
+-define(SD_EMERG,   "<0>"). % system is unusable
+-define(SD_ALERT,   "<1>"). % action must be taken immediately
+-define(SD_CRIT,    "<2>"). % critical conditions
+-define(SD_ERR,     "<3>"). % error conditions
+-define(SD_WARNING, "<4>"). % warning conditions
+-define(SD_NOTICE,  "<5>"). % normal but significant condition
+-define(SD_INFO,    "<6>"). % informational
+-define(SD_DEBUG,   "<7>"). % debug-level messages

--- a/src/systemd.erl
+++ b/src/systemd.erl
@@ -19,7 +19,7 @@
               sd_timeout/0]).
 
 -include_lib("kernel/include/file.hrl").
--include("systemd.hrl").
+-include("systemd_internal.hrl").
 
 -export([notify/1,
          notify/2,

--- a/src/systemd_app.erl
+++ b/src/systemd_app.erl
@@ -4,8 +4,6 @@
 
 -behaviour(application).
 
--include_lib("kernel/include/logger.hrl").
-
 -export([start/2,
          prep_stop/1,
          stop/1]).

--- a/src/systemd_formatter.erl
+++ b/src/systemd_formatter.erl
@@ -1,0 +1,37 @@
+-module(systemd_formatter).
+
+-include("systemd.hrl").
+
+-export([check_config/1,
+         format/2]).
+
+-spec check_config(logger:formatter_config()) -> ok | {error, term()}.
+check_config(Config0) ->
+    case maps:take(parent, Config0) of
+         {Formatter, Config} ->
+            case erlang:function_exported(Formatter, check_config, 1) of
+                true -> Formatter:check_config(Config);
+                _ -> ok
+            end;
+        error ->
+            logger_formatter:check_config(Config0)
+    end.
+
+-spec format(logger:log_event(), logger:formatter_config()) ->
+    unicode:chardata().
+format(#{level := Level}=LogEvent, Config0) ->
+    {Formatter, Config} = case maps:take(parent, Config0) of
+                              {FMod, Conf} -> {FMod, Conf};
+                              error -> {logger_formatter, Config0}
+                          end,
+    Message = Formatter:format(LogEvent, Config),
+    [format_level(Level), Message].
+
+format_level(emergency) -> ?SD_EMERG;
+format_level(alert)     -> ?SD_ALERT;
+format_level(critical)  -> ?SD_CRIT;
+format_level(error)     -> ?SD_ERR;
+format_level(warning)   -> ?SD_WARNING;
+format_level(notice)    -> ?SD_NOTICE;
+format_level(info)      -> ?SD_INFO;
+format_level(debug)     -> ?SD_DEBUG.

--- a/src/systemd_internal.hrl
+++ b/src/systemd_internal.hrl
@@ -1,2 +1,3 @@
+-define(SUPERVISOR, systemd_sup).
 -define(WATCHDOG, systemd_watchdog).
 -define(LISTEN_FDS_START, 3).

--- a/src/systemd_watchdog.erl
+++ b/src/systemd_watchdog.erl
@@ -5,7 +5,7 @@
 -behaviour(gen_server).
 
 -include_lib("kernel/include/logger.hrl").
--include("systemd.hrl").
+-include("systemd_internal.hrl").
 
 -export([start_link/1,
          init/1,

--- a/test/dumb_formatter.erl
+++ b/test/dumb_formatter.erl
@@ -1,0 +1,8 @@
+-module(dumb_formatter).
+
+-export([format/2]).
+
+-spec format(logger:log_event(), logger:formatter_config()) ->
+    unicode:chardata().
+format(#{msg:={string, Msg}}, _Config) ->
+    Msg.

--- a/test/systemd_formatter_SUITE.erl
+++ b/test/systemd_formatter_SUITE.erl
@@ -1,0 +1,54 @@
+-module(systemd_formatter_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() -> [default, custom_parent, log_prefix].
+
+default(_Config) ->
+    ok = systemd_formatter:check_config(#{}),
+    ok = systemd_formatter:check_config(#{depth => 2}),
+    {error, _} = systemd_formatter:check_config(#{unknown => 10}),
+
+    "<0>MESSAGE=foo" = format(emergency, {string, "foo"}, #{}, #{template => ["MESSAGE=", msg]}),
+    ok.
+
+custom_parent(_Config) ->
+    ok = systemd_formatter:check_config(#{parent => logger_formatter}),
+    ok = systemd_formatter:check_config(#{parent => logger_formatter,
+                                          depth => 2}),
+    {error, _} = systemd_formatter:check_config(#{parent => logger_formatter,
+                                                  unknown => 10}),
+    ok = systemd_formatter:check_config(#{parent => dumb_format}),
+    ok = systemd_formatter:check_config(#{parent => dumb_format,
+                                          unknown => 10}),
+    ok.
+
+log_prefix(_Config) ->
+    Config = #{parent => dumb_formatter},
+
+    "<0>foo" = format(emergency, {string, "foo"}, #{}, Config),
+    "<1>foo" = format(alert    , {string, "foo"}, #{}, Config),
+    "<2>foo" = format(critical , {string, "foo"}, #{}, Config),
+    "<3>foo" = format(error    , {string, "foo"}, #{}, Config),
+    "<4>foo" = format(warning  , {string, "foo"}, #{}, Config),
+    "<5>foo" = format(notice   , {string, "foo"}, #{}, Config),
+    "<6>foo" = format(info     , {string, "foo"}, #{}, Config),
+    "<7>foo" = format(debug    , {string, "foo"}, #{}, Config),
+    ok.
+
+% -----------------------------------------------------------------------------
+% Internal
+
+format(Level,Msg,Meta,Config) ->
+    format(#{level=>Level,msg=>Msg,meta=>add_time(Meta)},Config).
+
+format(Log,Config) ->
+    unicode:characters_to_list(systemd_formatter:format(Log,Config)).
+
+add_time(#{time := _}=Meta) ->
+    Meta;
+add_time(Meta) ->
+    Meta#{time => logger:timestamp()}.


### PR DESCRIPTION
This is simple systemd formatter for usage on stderr. This provides similar output format to Linux's kernel logging function `printk`.