### PR TITLE
Add `systemd:unset_env/1` for unsetting env variables

### DIFF
--- a/src/systemd.app.src
+++ b/src/systemd.app.src
@@ -10,7 +10,8 @@
     stdlib
    ]},
   {mod, {systemd_app, []}},
-  {env,[{watchdog_scale, 2},
+  {env,[{unset_env, true},
+        {watchdog_scale, 2},
         {logger,
          [{handler,
            systemd_journal,

--- a/src/systemd.erl
+++ b/src/systemd.erl
@@ -38,12 +38,53 @@
 -include_lib("kernel/include/file.hrl").
 -include("systemd_internal.hrl").
 
--export([notify/1,
+-export([unset_env/1,
+         notify/1,
          notify/2,
          watchdog/1,
          listen_fds/0,
-         listen_fds/1,
          booted/0]).
+
+%% @doc
+%% Unset environment variables for given subsystem.
+%%
+%% <dl>
+%%      <dt>`unset_env(notify)'</dt>
+%%      <dd>Unset variables used by {@link notify/1. `notify/1'}. This call will
+%%      be done automatically when the `unset_env' application option is set
+%%      (default). It is highly encouraged to unset these variables to prevent
+%%      them from being passed to subprocesses.</dd>
+%%      <dt>`unset_env(watchdog)'</dt>
+%%      <dd>Unset variables used by {@link watchdog/1. `watchdog/1'}. This call will
+%%      be done automatically when the `unset_env' application option is set
+%%      (default). It is highly encouraged to unset these variables to prevent
+%%      them from being passed to subprocesses.</dd>
+%%      <dt>`unset_env(listen_fds)'</dt>
+%%      <dd>Unset variables used by {@link listen_fds/0. `listen_fds/0'}. After
+%%      that all subsequent calls to `listen_fds' will return empty list. It is
+%%      highly encouraged to unset these variables to prevent them from being
+%%      passed to the subprocesses.</dd>
+%% </dl>
+%% @end
+-spec unset_env(Subsystem) -> ok
+                                when Subsystem ::
+                                     notify |
+                                     watchdog |
+                                     listen_fds.
+unset_env(notify) ->
+    os:unsetenv(?NOTIFY_SOCKET),
+    ok;
+unset_env(watchdog) ->
+    os:unsetenv(?WATCHDOG_PID),
+    os:unsetenv(?WATCHDOG_TIMEOUT),
+    ok;
+unset_env(listen_fds) ->
+    os:unsetenv(?LISTEN_PID),
+    os:unsetenv(?LISTEN_FDS),
+    os:unsetenv(?LISTEN_FDNAMES),
+    ok.
+
+%% ----------------------------------------------------------------------------
 
 %% @doc
 %% Send notification to the `systemd' socket.
@@ -197,43 +238,23 @@ booted() ->
 
 %% ----------------------------------------------------------------------------
 
--define(LISTEN_PID, "LISTEN_PID").
--define(LISTEN_FDS, "LISTEN_FDS").
--define(LISTEN_FDNAMES, "LISTEN_FDNAMES").
-
-%% @equiv listen_fds(false)
--spec listen_fds() -> [fd()].
-listen_fds() ->
-    listen_fds(false).
-
 %% @doc
 %% Returns list of file descriptors passed to the application by systemd.
-%%
-%% @param `Unset' if true then will unset all environment variables and all
-%% consecutive calls will return empty list.
 %%
 %% @returns List of passed file descriptors. If descriptor have name defined
 %% then it will be returned as 2nd value in tuple. Order of returned descriptors
 %% is the same as passed in environment.
 %% @end
--spec listen_fds(Unset :: boolean()) -> [fd()].
-listen_fds(Unset) ->
-    Fds = case check_listen_pid() of
-              true ->
-                  Count = listen_fds_count(),
-                  Names = listen_names(),
-                  generate_fds(Count, Names);
-              false ->
-                  []
-          end,
-    unsetenv_all(Unset),
-    Fds.
-
-unsetenv_all(false) -> true;
-unsetenv_all(true) ->
-    os:unsetenv(?LISTEN_PID),
-    os:unsetenv(?LISTEN_FDS),
-    os:unsetenv(?LISTEN_FDNAMES).
+-spec listen_fds() -> [fd()].
+listen_fds() ->
+    case check_listen_pid() of
+        true ->
+            Count = listen_fds_count(),
+            Names = listen_names(),
+            generate_fds(Count, Names);
+        false ->
+            []
+    end.
 
 check_listen_pid() ->
     os:getenv(?LISTEN_PID) == os:getpid().

--- a/src/systemd.erl
+++ b/src/systemd.erl
@@ -17,6 +17,8 @@
 %%
 %% @doc
 %% Functions for interacting with `systemd' features.
+%%
+%% @since 0.1.0
 %% @end
 -module(systemd).
 

--- a/src/systemd.erl
+++ b/src/systemd.erl
@@ -14,7 +14,10 @@
 %% KIND, either express or implied.  See the License for the
 %% specific language governing permissions and limitations
 %% under the License.
-
+%%
+%% @doc
+%% Functions for interacting with `systemd' features.
+%% @end
 -module(systemd).
 
 -type state() ::
@@ -48,6 +51,9 @@
 %% @doc
 %% Unset environment variables for given subsystem.
 %%
+%% Most environment variables will be cleaned on startup by default. To prevent
+%% such behaviour set `unset_env' application variable to `false'.
+%%
 %% <dl>
 %%      <dt>`unset_env(notify)'</dt>
 %%      <dd>Unset variables used by {@link notify/1. `notify/1'}. This call will
@@ -65,6 +71,8 @@
 %%      highly encouraged to unset these variables to prevent them from being
 %%      passed to the subprocesses.</dd>
 %% </dl>
+%%
+%% @since 0.4.0
 %% @end
 -spec unset_env(Subsystem) -> ok
                                 when Subsystem ::
@@ -129,6 +137,8 @@ unset_env(listen_fds) ->
 %%
 %%      This message must be sent within original timeout.</dd>
 %% </dl>
+%%
+%% @since 0.1.0
 %% @end
 -spec notify(State :: state()) -> ok.
 notify(State) ->
@@ -139,6 +149,8 @@ notify(State) ->
 %%
 %% This function takes `Format' and `Data' that will be formatted in the same
 %% way as `io:fwrite/2'.
+%%
+%% @since 0.1.0
 %% @end
 -spec notify(Format :: io:format(), Data :: [term()]) -> ok.
 notify(Format, Data) ->
@@ -197,6 +209,8 @@ normalize_state(Msg)
 %%
 %%      Defaults to `2' which will send messages twice as often as needed.</dd>
 %% </dl>
+%%
+%% @since 0.1.0
 %% @end
 -spec watchdog(state) -> sd_timeout()
                          ; (trigger) -> ok
@@ -227,6 +241,8 @@ watchdog(ping) ->
 %%
 %% @returns `{ok, true}' if system was booted with systemd, `{ok,false}' if not,
 %% and `{error, Reason}' on error.
+%%
+%% @since 0.1.0
 %% @end
 -spec booted() -> {ok, boolean()} | {error, file:posix()}.
 booted() ->
@@ -244,6 +260,8 @@ booted() ->
 %% @returns List of passed file descriptors. If descriptor have name defined
 %% then it will be returned as 2nd value in tuple. Order of returned descriptors
 %% is the same as passed in environment.
+%%
+%% @since 0.2.0
 %% @end
 -spec listen_fds() -> [fd()].
 listen_fds() ->

--- a/src/systemd_internal.hrl
+++ b/src/systemd_internal.hrl
@@ -16,5 +16,14 @@
 %% under the License.
 %%
 -define(SUPERVISOR, systemd_sup).
+
 -define(WATCHDOG, systemd_watchdog).
+-define(WATCHDOG_PID, "WATCHDOG_PID").
+-define(WATCHDOG_TIMEOUT, "WATCHDOG_USEC").
+
+-define(NOTIFY_SOCKET, "NOTIFY_SOCKET").
+
 -define(LISTEN_FDS_START, 3).
+-define(LISTEN_PID, "LISTEN_PID").
+-define(LISTEN_FDS, "LISTEN_FDS").
+-define(LISTEN_FDNAMES, "LISTEN_FDNAMES").

--- a/src/systemd_journal_formatter.erl
+++ b/src/systemd_journal_formatter.erl
@@ -185,6 +185,8 @@
 %% will be similar to one provided by `logger:format_report/1', but this one
 %% takes also additional parameter `Perfix' which should be used as prefix for
 %% all generated fields.
+%%
+%% @since 0.3.0
 %% @end
 -spec format_report(Prefix :: field_name(), logger:report()) -> [field()].
 format_report(Prefix, Report) ->

--- a/src/systemd_journal_h.erl
+++ b/src/systemd_journal_h.erl
@@ -36,6 +36,8 @@
 %% This logger <b>should</b> always be used with `systemd_journal_formatter' unless
 %% you are completely sure what you are trying to do. Otherwise you can loose your
 %% log data.
+%%
+%% @since 0.3.0
 %% @end
 -module(systemd_journal_h).
 

--- a/src/systemd_journal_h.erl
+++ b/src/systemd_journal_h.erl
@@ -67,7 +67,8 @@
 % Logger Handler
 
 %% @hidden
--spec adding_handler(logger:handler_config()) -> logger:handler_config().
+-spec adding_handler(logger:handler_config()) -> {ok, logger:handler_config()} |
+                                                 {error, term()}.
 adding_handler(HConfig) ->
     Config = maps:get(config, HConfig, #{}),
     Path = maps:get(path, Config, ?JOURNAL_SOCKET),

--- a/src/systemd_stderr_formatter.erl
+++ b/src/systemd_stderr_formatter.erl
@@ -43,6 +43,7 @@
 %%
 %% Rest of the options will be passed to `parent' with this option removed.
 %%
+%% @since 0.3.0
 %% @end
 -module(systemd_stderr_formatter).
 


### PR DESCRIPTION
This provides user greater control about the environment variables.

BREAKING CHANGE: remove `systemd:listen_fds/1` in favour of `systemd:listen_fds(), systemd:unset_env(listen_fds).`