### PR TITLE
Prefix all lines instead of only first one

### DIFF
--- a/src/systemd_stderr_formatter.erl
+++ b/src/systemd_stderr_formatter.erl
@@ -34,6 +34,7 @@
 -export([check_config/1,
          format/2]).
 
+%% @hidden
 -spec check_config(logger:formatter_config()) -> ok | {error, term()}.
 check_config(Config0) ->
     case maps:take(parent, Config0) of
@@ -46,6 +47,7 @@ check_config(Config0) ->
             logger_formatter:check_config(Config0)
     end.
 
+%% @hidden
 -spec format(logger:log_event(), logger:formatter_config()) ->
     unicode:chardata().
 format(#{level := Level}=LogEvent, Config0) ->

--- a/src/systemd_stderr_formatter.erl
+++ b/src/systemd_stderr_formatter.erl
@@ -53,8 +53,10 @@ format(#{level := Level}=LogEvent, Config0) ->
                               {FMod, Conf} -> {FMod, Conf};
                               error -> {logger_formatter, Config0}
                           end,
-    Message = Formatter:format(LogEvent, Config),
-    [format_level(Level), Message].
+    Priority = format_level(Level),
+    Message0 = Formatter:format(LogEvent, Config),
+    Message = string:replace(Message0, "\n", [$\n, Priority], all),
+    [Priority | Message].
 
 format_level(emergency) -> ?SD_EMERG;
 format_level(alert)     -> ?SD_ALERT;

--- a/test/dumb_formatter.erl
+++ b/test/dumb_formatter.erl
@@ -4,5 +4,5 @@
 
 -spec format(logger:log_event(), logger:formatter_config()) ->
     unicode:chardata().
-format(LogEvent, _Config) ->
-    logger_formatter:format(LogEvent, #{template => [msg]}).
+format(LogEvent, Config) ->
+    logger_formatter:format(LogEvent, Config#{template => [msg]}).

--- a/test/systemd_stderr_formatter_SUITE.erl
+++ b/test/systemd_stderr_formatter_SUITE.erl
@@ -27,16 +27,20 @@ custom_parent(_Config) ->
     ok.
 
 log_prefix(_Config) ->
-    Config = #{parent => dumb_formatter},
+    Config0 = #{parent => dumb_formatter},
 
-    "<0>foo" = format(emergency, {string, "foo"}, #{}, Config),
-    "<1>foo" = format(alert    , {string, "foo"}, #{}, Config),
-    "<2>foo" = format(critical , {string, "foo"}, #{}, Config),
-    "<3>foo" = format(error    , {string, "foo"}, #{}, Config),
-    "<4>foo" = format(warning  , {string, "foo"}, #{}, Config),
-    "<5>foo" = format(notice   , {string, "foo"}, #{}, Config),
-    "<6>foo" = format(info     , {string, "foo"}, #{}, Config),
-    "<7>foo" = format(debug    , {string, "foo"}, #{}, Config),
+    "<0>foo" = format(emergency, {string, "foo"}, #{}, Config0),
+    "<1>foo" = format(alert    , {string, "foo"}, #{}, Config0),
+    "<2>foo" = format(critical , {string, "foo"}, #{}, Config0),
+    "<3>foo" = format(error    , {string, "foo"}, #{}, Config0),
+    "<4>foo" = format(warning  , {string, "foo"}, #{}, Config0),
+    "<5>foo" = format(notice   , {string, "foo"}, #{}, Config0),
+    "<6>foo" = format(info     , {string, "foo"}, #{}, Config0),
+    "<7>foo" = format(debug    , {string, "foo"}, #{}, Config0),
+
+    Config1 = Config0#{single_line => false},
+    "<0>foo\n<0>bar" = format(emergency, {string, "foo\nbar"}, #{}, Config1),
+
     ok.
 
 % -----------------------------------------------------------------------------


### PR DESCRIPTION
Earlier only first line in log was prefixed, this could cause problems
in multiline logger formatters where subsequent lines would result with
wrong priority.