### PR TITLE
Always set timeout from var

### DIFF
--- a/src/systemd_watchdog.erl
+++ b/src/systemd_watchdog.erl
@@ -32,11 +32,11 @@
 
 -record(state, {timeout, enabled=true}).
 
-start_link(Timeout) ->
-    gen_server:start_link({local, ?WATCHDOG}, ?MODULE, Timeout, []).
+start_link(Config) ->
+    gen_server:start_link({local, ?WATCHDOG}, ?MODULE, Config, []).
 
-init(Timeout) ->
-    State = #state{timeout=Timeout},
+init({Enabled, Timeout}) ->
+    State = #state{enabled=Enabled, timeout=Timeout},
     notify(State),
     {ok, State}.
 


### PR DESCRIPTION
This allows forcing enabling the Watchdog if it wasn't run by default
due to different requested PIDs.

Close #13