### PR TITLE
Add helper for readiness process child_spec

### DIFF
--- a/test/mock_supervisor.erl
+++ b/test/mock_supervisor.erl
@@ -1,0 +1,12 @@
+-module(mock_supervisor).
+
+-behaviour(supervisor).
+
+-export([start_link/1,
+         init/1]).
+
+start_link(Children) ->
+    supervisor:start_link(?MODULE, Children).
+
+init(Children) ->
+    {ok, {#{strategy => one_for_one}, Children}}.

--- a/test/systemd_SUITE.erl
+++ b/test/systemd_SUITE.erl
@@ -5,7 +5,7 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> [notify, watchdog, listen_fds, socket].
+all() -> [notify, watchdog, ready, listen_fds, socket].
 
 init_per_testcase(Name, Config0) ->
     PrivDir = ?config(priv_dir, Config0),
@@ -36,7 +36,8 @@ end_per_testcase(Name, Config0) ->
 notify(init, Config) ->
     ok = start_with_socket(?config(socket, Config)),
     Config;
-notify(_, Config) -> Config.
+notify(_, Config) ->
+    Config.
 
 notify(Config) ->
     Pid = ?config(mock_pid, Config),
@@ -252,6 +253,23 @@ watchdog(Config) ->
     ok = stop(Config),
 
     ok.
+
+ready(init, Config) ->
+    ok = start_with_socket(?config(socket, Config)),
+    Config;
+ready(_, Config) ->
+    stop(Config),
+    Config.
+
+ready(Config) ->
+    Pid = ?config(mock_pid, Config),
+    {ok, _Pid} = mock_supervisor:start_link([systemd:ready()]),
+    ct:sleep(10),
+
+    ?assertEqual(["READY=1\n"], mock_systemd:messages(Pid)),
+
+    ok.
+
 
 listen_fds(init, Config) -> Config;
 listen_fds(finish, Config) ->


### PR DESCRIPTION
This function is meant to be used as part of the supervisor child list in the place where system is ready (there still can be processes to be started, but these should not be vital to the whole system). It will just start temporary process that send message and exits.