### PR TITLE
systemd_journal_h: Support literal field values

### DIFF
--- a/src/systemd_journal_h.erl
+++ b/src/systemd_journal_h.erl
@@ -344,11 +344,15 @@ get_field(priority, #{level := Level}) ->
     level_to_char(Level);
 get_field(level, #{level := Level}) ->
     atom_to_binary(Level, utf8);
-get_field(Metakey, #{meta := Meta}) ->
+get_field(Metakey, #{meta := Meta})
+  when is_atom(Metakey) orelse
+       (is_list(Metakey) andalso is_atom(hd(Metakey))) ->
     case get_meta(Metakey, Meta) of
         undefined -> "";
         Data -> to_string(Data)
-    end.
+    end;
+get_field(Iolist, _) when is_list(Iolist) orelse is_binary(Iolist) ->
+    Iolist.
 
 get_meta([], Data) ->
     Data;

--- a/test/systemd_journal_h_SUITE.erl
+++ b/test/systemd_journal_h_SUITE.erl
@@ -239,6 +239,14 @@ output(_Config) ->
     {log, <<"MESSAGE=foo\n">>} = log(debug, "foo", #{foo => 1}),
     {log, <<"MESSAGE=foo\nFOO=1\n">>} = log(debug, "foo", #{foo => #{bar => 1}}),
 
+    % Literal field values
+    ok = logger:update_handler_config(example, config, #{fields => [{"FOO", "BAR"}]}),
+    {log, <<"MESSAGE=foo\nFOO=BAR\n">>} = log(debug, "foo", #{}),
+    ok = logger:update_handler_config(example, config, #{fields => [{"FOO", <<"BAR">>}]}),
+    {log, <<"MESSAGE=foo\nFOO=BAR\n">>} = log(debug, "foo", #{}),
+    ok = logger:update_handler_config(example, config, #{fields => [{"FOO", [$B, <<"A">>, "R"]}]}),
+    {log, <<"MESSAGE=foo\nFOO=BAR\n">>} = log(debug, "foo", #{}),
+
     % Empty messages aren't sent at all
     ok = logger:set_handler_config(example, config, #{}),
     nolog = log(info, "", #{}),


### PR DESCRIPTION
They were already documented at the top of the file but not implemented. Before this patch, the literal value was ignored (because not matching a metadata key) and the field was set to an empty string.