### PR TITLE
systemd_protocol: Keep empty values in encode_field/2

### DIFF
--- a/src/systemd_protocol.erl
+++ b/src/systemd_protocol.erl
@@ -35,17 +35,13 @@ encode(Fields) when is_list(Fields) ->
 %% @end
 -spec encode_field(Name::field_name(), Data::field_data()) -> iodata().
 encode_field(Name, Data) ->
-    case string:is_empty(Data) of
-        true -> [];
-        false ->
-            Sep = case string:find(Data, "\n") of
-                          nomatch -> "=";
-                          _ ->
-                              Len = iolist_size(Data),
-                              [$\n, <<Len:64/integer-little>>]
-                      end,
-            [field_name(Name), Sep, Data, $\n]
-    end.
+    Sep = case string:find(Data, "\n") of
+                  nomatch -> "=";
+                  _ ->
+                      Len = iolist_size(Data),
+                      [$\n, <<Len:64/integer-little>>]
+              end,
+    [field_name(Name), Sep, Data, $\n].
 
 -spec field_name(field_name()) -> unicode:chardata().
 field_name(Atom) when is_atom(Atom) ->

--- a/test/systemd_SUITE.erl
+++ b/test/systemd_SUITE.erl
@@ -249,7 +249,7 @@ fds(Config) ->
     ok = systemd:store_fds([1]),
     ?assertMatch(
         {ok, #{
-            iov := [<<"FDSTORE=1\n">>],
+            iov := [<<"FDSTORE=1\nFDNAMES=\n">>],
             ctrl := [#{type := rights}]
         }},
         recvmsg(Socket)

--- a/test/systemd_journal_h_SUITE.erl
+++ b/test/systemd_journal_h_SUITE.erl
@@ -216,7 +216,7 @@ output(_Config) ->
 
     % Simple metadata access
     ok = logger:update_handler_config(example, config, #{fields => [foo]}),
-    {log, <<"MESSAGE=foo\n">>} = log(debug, "foo", #{}),
+    {log, <<"MESSAGE=foo\nFOO=\n">>} = log(debug, "foo", #{}),
     {log, <<"MESSAGE=foo\nFOO=1\n">>} = log(debug, "foo", #{foo => 1}),
     {log, <<"MESSAGE=foo\nFOO=foo\n">>} = log(debug, "foo", #{foo => "foo"}),
     {log, <<"MESSAGE=foo\nFOO=foo\n">>} = log(debug, "foo", #{foo => <<"foo">>}),
@@ -235,8 +235,8 @@ output(_Config) ->
 
     % Nested metadata access
     ok = logger:update_handler_config(example, config, #{fields => [{"FOO", [foo, bar]}]}),
-    {log, <<"MESSAGE=foo\n">>} = log(debug, "foo", #{}),
-    {log, <<"MESSAGE=foo\n">>} = log(debug, "foo", #{foo => 1}),
+    {log, <<"MESSAGE=foo\nFOO=\n">>} = log(debug, "foo", #{}),
+    {log, <<"MESSAGE=foo\nFOO=\n">>} = log(debug, "foo", #{foo => 1}),
     {log, <<"MESSAGE=foo\nFOO=1\n">>} = log(debug, "foo", #{foo => #{bar => 1}}),
 
     % Literal field values


### PR DESCRIPTION
One use case if when the caller wants to clear the `STATUS` of a service using `systemd:notify({status, ""})`.

Fixes #26.