### PR TITLE
Add Erlang 24 support

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,8 +6,13 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        erlang_version:
+        - "23"
+        - "24"
     container:
-      image: erlang:23
+      image: erlang:${{ matrix.erlang_version }}
     steps:
     - uses: actions/checkout@v1
     - name: Compile

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         erlang_version:
         - "23"

--- a/test/systemd_SUITE.erl
+++ b/test/systemd_SUITE.erl
@@ -21,7 +21,10 @@ init_per_testcase(Name, Config0) ->
     PrivDir = ?config(priv_dir, Config0),
     Path = socket_path(PrivDir),
     {ok, Socket} = socket:open(local, dgram, default),
-    {ok, _Port} = socket:bind(Socket, #{family => local, path => Path}),
+    case socket:bind(Socket, #{family => local, path => Path}) of
+        {ok, _Port} -> ok; %% Erlang up to 23
+        ok          -> ok  %% Erlang 24+
+    end,
     Config1 = [{socket, Socket}, {path, Path} | Config0],
 
     case erlang:function_exported(?MODULE, Name, 2) of

--- a/test/systemd_test_utils.erl
+++ b/test/systemd_test_utils.erl
@@ -24,11 +24,13 @@ start_with_socket(Socket) ->
     {ok, #{path := Path}} = socket:sockname(Socket),
     start_with_path(Path).
 
-start_with_path(Path) ->
+start_with_path(Path) when is_list(Path) ->
     ct:log("Start app with socket at ~p", [Path]),
     os:putenv("NOTIFY_SOCKET", Path),
     {ok, _} = application:ensure_all_started(systemd),
-    ok.
+    ok;
+start_with_path(Path) when is_binary(Path) ->
+    start_with_path(binary_to_list(Path)).
 
 stop(Config) ->
     ok = application:stop(systemd),

--- a/test/systemd_watchdog_SUITE.erl
+++ b/test/systemd_watchdog_SUITE.erl
@@ -95,7 +95,10 @@ init_per_testcase(_Name, Config0) ->
     os:putenv("WATCHDOG_PID", os:getpid()),
     os:putenv("WATCHDOG_USEC", integer_to_list(Timeout0)),
     {ok, Socket} = socket:open(local, dgram, default),
-    {ok, _Port} = socket:bind(Socket, #{family => local, path => Path}),
+    case socket:bind(Socket, #{family => local, path => Path}) of
+        {ok, _Port} -> ok; %% Erlang up to 23
+        ok          -> ok  %% Erlang 24+
+    end,
     [{socket, Socket}, {path, Path}, {timeout, Timeout} | Config1].
 
 end_per_testcase(_Name, Config) ->


### PR DESCRIPTION
There are three parts in this pull request:
  1. An update to the GitHub workflow to test against Erlang 23 and 24, thanks to @pjk25.
  2. Various changes to the testsuites to make them work on Erlang 24.
  3. A change to the message encoding to fix the library on Erlang 24.

Without the latest point, RabbitMQ master branch fails to notify systemd with the `{error, {invalid, {iov, {element_not_binary, 1}}}}` and the start command hangs.